### PR TITLE
fix(rabbitmq): fix vulnerability in amqp-client CVE-2018-11087

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <url>https://github.com/jocelyndrean/kafka-connect-rabbitmq/issues</url>
     </issueManagement>
     <properties>
-        <rabbitmq.version>4.2.0</rabbitmq.version>
+        <rabbitmq.version>4.8.0</rabbitmq.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
CVE-2018-11087 (moderate severity)
Vulnerable versions: < 4.8.0
Patched version: 4.8.0

Description about CVE-2018-11087
Pivotal Spring AMQP, 1.x versions prior to 1.7.10 and 2.x versions prior to 2.0.6, expose a man-in-the-middle vulnerability due to lack of hostname validation. A malicious user that has the ability to intercept traffic would be able to view data in transit.